### PR TITLE
fix metadata type

### DIFF
--- a/ckafka_input.go
+++ b/ckafka_input.go
@@ -150,9 +150,13 @@ func (p *CkafkaInput) ReadOneEvent() map[string]interface{} {
 	event := p.decoder.Decode(message.Value)
 	if p.decorateEvents {
 		kafkaMeta := make(map[string]interface{})
-		kafkaMeta["topic"] = topicPartition.Topic
+		var topic string
+		if topicPartition.Topic != nil {
+			topic = *topicPartition.Topic
+		}
+		kafkaMeta["topic"] = topic
 		kafkaMeta["partition"] = topicPartition.Partition
-		kafkaMeta["offset"] = topicPartition.Offset
+		kafkaMeta["offset"] = int64(topicPartition.Offset)
 		event["@metadata"] = map[string]interface{}{"kafka": kafkaMeta}
 	}
 	return event


### PR DESCRIPTION
`*string` which is the type of `topicPartition.Topic`  is not match with `string` which is the type of `"topic"` when using condition filter like 'EQ($.@metadata.kafka.topic,"topic")'